### PR TITLE
Potential Bash Solution

### DIFF
--- a/Project/FinalProduct/bluetooth
+++ b/Project/FinalProduct/bluetooth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+gcc -o toggleon toggleon.c && gcc -o toggleoff toggleoff.c
+
+$PWD/toggle"$1"

--- a/Project/FinalProduct/toggleoff.c
+++ b/Project/FinalProduct/toggleoff.c
@@ -1,0 +1,10 @@
+#include "unistd.h"
+
+#define PATH_TO_BLUETOOTH_SERVICE "/etc/init.d/bluetooth"
+#define STOP_CMD "stop"
+
+int main(void)
+{
+    execl(PATH_TO_BLUETOOTH_SERVICE, PATH_TO_BLUETOOTH_SERVICE, STOP_CMD, NULL);
+    return 0;
+}

--- a/Project/FinalProduct/toggleon.c
+++ b/Project/FinalProduct/toggleon.c
@@ -1,0 +1,10 @@
+#include "unistd.h"
+
+#define PATH_TO_BLUETOOTH_SERVICE "/etc/init.d/bluetooth"
+#define START_CMD "start"
+
+int main(void)
+{
+    execl(PATH_TO_BLUETOOTH_SERVICE, PATH_TO_BLUETOOTH_SERVICE, START_CMD, NULL);
+    return 0;
+}


### PR DESCRIPTION
Potential Bash Solution for enabling bluetooth from the command line so we can at least have a solution for the Project. 

One can created an alias within ~/.bashrc, which is essentially a bash script that initializes an interactive shell session, for the quick "bluetooth' bash script I created in order to execute either the "bluetooth on" or "bluetooth off" command globally. 

Using this method, we can type the command at the command prompt and enable/disable the bluetooth service using the previous commands.

Not sure what happened but add/edit anything you guys see fit and/or can be improved!
